### PR TITLE
Add Disclaimer to Homepage

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/core": "7.1.0",
+    "@bit/mybit.ui.home-page-disclaimer": "^0.0.1",
     "@bit/mybit.ui.showcase.address": "0.0.1",
     "@bit/mybit.ui.showcase.button": "0.0.3",
     "@svgr/webpack": "2.4.1",

--- a/front-end/src/containers/HomePage/index.js
+++ b/front-end/src/containers/HomePage/index.js
@@ -7,6 +7,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import styled from 'styled-components/macro';
+import HomePageDisclaimer from '@bit/mybit.ui.home-page-disclaimer';
 
 import H1 from 'components/H1';
 import P from 'components/P';
@@ -116,6 +117,7 @@ export class HomePage extends React.PureComponent {
             Contribute
           </Button>
         </StyledCenterButton>
+        <HomePageDisclaimer />
       </StyledPage>
     );
   }


### PR DESCRIPTION
Fixes [Issue #6](https://github.com/MyBitFoundation/MyBit-Payroll.tech/issues/6)
Status: Ready

### Implemented and working:
* Add disclaimer to the homepage

### Review notes:
Main changes from `MyBit-Payroll.tech` code in:

* [HomePage/index.js](https://github.com/65black/MyBit-Payroll.tech/blob/master/front-end/src/containers/HomePage/index.js)

### How to test:
* Clone this repo, and navigate to the `front-end` folder
* Run `yarn` and then run `npm run start`
* Observe the disclaimer on the home page
